### PR TITLE
Add Anthropic Compatible provider with configurable base URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
                                     <option value="openrouter">OpenRouter</option>
                                     <option value="gemini">Gemini</option>
                                     <option value="anthropic">Anthropic</option>
+                                    <option value="anthropic_compatible">Anthropic Compatible</option>
                                     <option value="deepseek">DeepSeek</option>
                                     <option value="xai">xAI</option>
                                     <option value="cohere">Cohere</option>

--- a/js/api/providers.js
+++ b/js/api/providers.js
@@ -67,6 +67,14 @@ const Providers = {
             supportsModels: true,
             supportedModes: ['text', 'image', 'audio', 'video']
         },
+        anthropic_compatible: {
+            name: 'Anthropic Compatible',
+            baseUrl: '',
+            models: [],
+            supportsStreaming: true,
+            supportsModels: true,
+            supportedModes: ['text']
+        },
         openai: {
             name: 'OpenAI',
             baseUrl: 'https://api.openai.com/v1',
@@ -239,7 +247,7 @@ const Providers = {
     getBaseUrl(providerId, customBaseUrl = '', corsProxyEnabled = false) {
         let baseUrl;
         
-        if (providerId === 'openai_compatible') {
+        if (providerId === 'openai_compatible' || providerId === 'anthropic_compatible') {
             baseUrl = customBaseUrl.replace(/\/$/, '');
         } else {
             const config = this.configs[providerId];
@@ -266,7 +274,7 @@ const Providers = {
             'Content-Type': 'application/json'
         };
 
-        if (providerId === 'anthropic') {
+        if (providerId === 'anthropic' || providerId === 'anthropic_compatible') {
             headers['x-api-key'] = apiKey;
             headers['anthropic-version'] = '2023-06-01';
             headers['anthropic-dangerous-direct-browser-access'] = 'true';
@@ -392,7 +400,7 @@ const Providers = {
         if (stream === true) {
             body.stream = true;
             // Add stream_options for usage info in streaming mode (OpenAI compatible)
-            if (provider !== 'anthropic') {
+            if (provider !== 'anthropic' && provider !== 'anthropic_compatible') {
                 body.stream_options = { include_usage: true };
             }
         } else {
@@ -412,7 +420,7 @@ const Providers = {
         }
 
         // Anthropic requires max_tokens
-        if (provider === 'anthropic' && !body.max_tokens) {
+        if ((provider === 'anthropic' || provider === 'anthropic_compatible') && !body.max_tokens) {
             body.max_tokens = 4096;
         }
 
@@ -425,7 +433,7 @@ const Providers = {
      * @returns {string} Endpoint path
      */
     getChatEndpoint(provider) {
-        if (provider === 'anthropic') {
+        if (provider === 'anthropic' || provider === 'anthropic_compatible') {
             return '/messages';
         }
         return '/chat/completions';

--- a/js/ui/forms.js
+++ b/js/ui/forms.js
@@ -406,7 +406,7 @@ const Forms = {
     updateBaseUrlVisibility(provider) {
         const baseUrlContainer = document.getElementById('base-url-container');
         if (baseUrlContainer) {
-            baseUrlContainer.classList.toggle('hidden', provider !== 'openai_compatible');
+            baseUrlContainer.classList.toggle('hidden', provider !== 'openai_compatible' && provider !== 'anthropic_compatible');
         }
     },
 


### PR DESCRIPTION
Adds a new **Anthropic Compatible** provider option to the API Tester, allowing users to specify a custom base URL for Anthropic-protocol-compatible endpoints (e.g. proxies, self-hosted deployments, or services like OpenRouter).

The provider uses Anthropic's API format — `x-api-key` headers, `/messages` endpoint, and automatic `max_tokens` — while letting users freely configure the base URL, just like the existing OpenAI Compatible option.

Changes span `index.html` (new dropdown option), `js/api/providers.js` (provider config + 5 method updates), and `js/ui/forms.js` (base URL field visibility).