### PR TITLE
Allow custom Anthropic base URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
                                 </select>
                             </div>
                             
-                            <!-- Base URL (for OpenAI Compatible) -->
+                            <!-- Base URL (for compatible providers) -->
                             <div class="provider-field" id="base-url-container">
                                 <label class="provider-field-label" for="base-url-input">Base URL</label>
                                 <input type="text" class="form-input" id="base-url-input" placeholder="https://api.example.com/v1">

--- a/js/api/providers.js
+++ b/js/api/providers.js
@@ -62,6 +62,7 @@ const Providers = {
         openai_compatible: {
             name: 'OpenAI Compatible',
             baseUrl: '',
+            supportsCustomBaseUrl: true,
             models: [],
             supportsStreaming: true,
             supportsModels: true,
@@ -98,6 +99,7 @@ const Providers = {
         anthropic: {
             name: 'Anthropic',
             baseUrl: 'https://api.anthropic.com/v1',
+            supportsCustomBaseUrl: true,
             models: [
                 'claude-sonnet-4-5-20250929', 'claude-3-5-sonnet-20241022', 
                 'claude-3-5-haiku-20241022', 'claude-3-opus-20240229'
@@ -232,18 +234,19 @@ const Providers = {
     /**
      * Get base URL for provider
      * @param {string} providerId - Provider ID
-     * @param {string} customBaseUrl - Custom base URL (for openai_compatible)
+     * @param {string} customBaseUrl - Custom base URL (for compatible providers)
      * @param {boolean} corsProxyEnabled - Whether to use CORS proxy (default: false)
      * @returns {string} Base URL
      */
     getBaseUrl(providerId, customBaseUrl = '', corsProxyEnabled = false) {
         let baseUrl;
+        const config = this.configs[providerId];
         
-        if (providerId === 'openai_compatible') {
-            baseUrl = customBaseUrl.replace(/\/$/, '');
+        if (!config) return '';
+
+        if (config.supportsCustomBaseUrl && customBaseUrl.trim()) {
+            baseUrl = customBaseUrl.trim().replace(/\/$/, '');
         } else {
-            const config = this.configs[providerId];
-            if (!config) return '';
             baseUrl = config.baseUrl || '';
         }
         

--- a/js/ui/forms.js
+++ b/js/ui/forms.js
@@ -406,7 +406,8 @@ const Forms = {
     updateBaseUrlVisibility(provider) {
         const baseUrlContainer = document.getElementById('base-url-container');
         if (baseUrlContainer) {
-            baseUrlContainer.classList.toggle('hidden', provider !== 'openai_compatible');
+            const customBaseUrlProviders = ['openai_compatible', 'anthropic'];
+            baseUrlContainer.classList.toggle('hidden', !customBaseUrlProviders.includes(provider));
         }
     },
 

--- a/tests/provider-settings.test.js
+++ b/tests/provider-settings.test.js
@@ -1,0 +1,56 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const rootDir = path.resolve(__dirname, '..');
+
+function loadProviders() {
+    const sandbox = { window: {} };
+    const source = fs.readFileSync(path.join(rootDir, 'js/api/providers.js'), 'utf8');
+    vm.runInNewContext(source, sandbox);
+    return sandbox.window.Providers;
+}
+
+function loadForms(document) {
+    const sandbox = { window: {}, document };
+    const source = fs.readFileSync(path.join(rootDir, 'js/ui/forms.js'), 'utf8');
+    vm.runInNewContext(source, sandbox);
+    return sandbox.window.Forms;
+}
+
+test('Anthropic provider uses a custom base URL when one is configured', () => {
+    const Providers = loadProviders();
+
+    const baseUrl = Providers.getBaseUrl('anthropic', 'https://anthropic-compatible.example/v1/');
+
+    assert.equal(baseUrl, 'https://anthropic-compatible.example/v1');
+});
+
+test('base URL field is visible for Anthropic-compatible providers', () => {
+    const classList = {
+        hidden: false,
+        toggle(className, force) {
+            assert.equal(className, 'hidden');
+            this.hidden = force;
+        }
+    };
+
+    const document = {
+        getElementById(id) {
+            assert.equal(id, 'base-url-container');
+            return { classList };
+        }
+    };
+    const Forms = loadForms(document);
+
+    Forms.updateBaseUrlVisibility('anthropic');
+    assert.equal(classList.hidden, false);
+
+    Forms.updateBaseUrlVisibility('openai_compatible');
+    assert.equal(classList.hidden, false);
+
+    Forms.updateBaseUrlVisibility('openai');
+    assert.equal(classList.hidden, true);
+});


### PR DESCRIPTION
## Summary
- Allow the Anthropic provider to use the sidebar Base URL when configured, while keeping the default Anthropic URL as fallback.
- Show the Base URL field for Anthropic as well as OpenAI Compatible providers.
- Add a Node regression test covering Anthropic custom base URL handling and field visibility.

## Checks
- node --test tests/provider-settings.test.js
- zsh -lc 'for f in js/**/*.js; do node --check "$f" || exit 1; done'