### PR TITLE
Uncodexify API tester UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # API Tester v2
 
-A modern, web-based API testing tool for AI models with a beautiful glassmorphism UI.
+A modern, web-based API testing tool for AI models with a clean app UI.
 
 ## 🌐 Live Demo
 
@@ -37,7 +37,7 @@ Access the hosted version directly at **https://aculnaj.github.io/api-tester**
 - ElevenLabs
 
 ### UI Features
-- 🎨 Modern glassmorphism design
+- 🎨 Clean responsive design
 - 🌙 Dark/Light/System theme support
 - 📱 Responsive layout (mobile-friendly)
 - 💾 Local storage for settings persistence
@@ -57,7 +57,7 @@ Visit **https://aculnaj.github.io/api-tester** to use the tool directly.
    ```bash
    # Python
    python3 -m http.server 8080
-   
+
    # Node.js
    npx serve
    ```

--- a/css/animations.css
+++ b/css/animations.css
@@ -78,12 +78,12 @@
 
 /* ========== Scale Animations ========== */
 .scale-in {
-    animation: scale-in var(--transition-base) ease-out;
+    animation: fade-in var(--transition-base) ease-out;
 }
 
 @keyframes scale-in {
-    from { opacity: 0; transform: scale(0.95); }
-    to { opacity: 1; transform: scale(1); }
+    from { opacity: 0; }
+    to { opacity: 1; }
 }
 
 /* ========== Spin Animation ========== */
@@ -106,21 +106,20 @@
     50% { opacity: 0.5; }
 }
 
-/* ========== Accent Breathing Animation ========== */
+/* ========== Subtle Border Animation ========== */
 .accent-breathe {
     animation: accent-breathe 2.4s ease-in-out infinite alternate;
 }
 
 @keyframes accent-breathe {
-    from { box-shadow: var(--shadow-inner), 0 10px 28px -26px rgba(91, 141, 239, 0.45); }
-    to { box-shadow: var(--shadow-inner), 0 14px 34px -24px rgba(91, 141, 239, 0.72); }
+    from { border-color: var(--color-border); }
+    to { border-color: var(--color-border-hover); }
 }
 
 /* ========== Skeleton Loading ========== */
 .skeleton-loading {
-    background: linear-gradient(90deg, var(--color-glass) 25%, var(--color-glass-hover) 50%, var(--color-glass) 75%);
-    background-size: 200% 100%;
-    animation: skeleton-loading 1.5s ease-in-out infinite;
+    background: var(--color-bg-tertiary);
+    animation: pulse 1.5s ease-in-out infinite;
 }
 
 @keyframes skeleton-loading {
@@ -134,7 +133,6 @@
 }
 
 .hover-lift:hover {
-    transform: translateY(-2px);
     box-shadow: var(--shadow-lg);
 }
 
@@ -143,7 +141,7 @@
 }
 
 .hover-scale:hover {
-    transform: scale(1.02);
+    opacity: 0.9;
 }
 
 /* ========== Loading Dots ========== */

--- a/css/base.css
+++ b/css/base.css
@@ -26,18 +26,14 @@ body {
     font-weight: var(--font-weight-normal);
     line-height: var(--line-height-normal);
     color: var(--color-text-primary);
-    background:
-        radial-gradient(circle at top right, rgba(91, 141, 239, 0.08), transparent 34rem),
-        linear-gradient(180deg, #0c1017 0%, var(--color-bg-primary) 22rem);
+    background: var(--color-bg-primary);
     min-height: 100vh;
     overflow-x: hidden;
-    transition: background var(--transition-slow), color var(--transition-slow);
+    transition: background-color var(--transition-slow), color var(--transition-slow);
 }
 
 [data-theme="light"] body {
-    background:
-        radial-gradient(circle at top right, rgba(91, 141, 239, 0.12), transparent 32rem),
-        linear-gradient(180deg, #ffffff 0%, var(--color-bg-primary) 22rem);
+    background: var(--color-bg-primary);
 }
 
 /* ========== Typography ========== */
@@ -201,8 +197,8 @@ legend {
 }
 
 :focus-visible {
-    outline: 2px solid rgba(91, 141, 239, 0.72);
-    outline-offset: 3px;
+    outline: 2px solid var(--color-text-tertiary);
+    outline-offset: 2px;
 }
 
 /* ========== Selection ========== */

--- a/css/buttons.css
+++ b/css/buttons.css
@@ -15,17 +15,14 @@
     font-weight: var(--font-weight-medium);
     line-height: 1;
     color: var(--color-text-primary);
-    background-color: rgba(255, 255, 255, 0.035);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     cursor: pointer;
-    box-shadow: var(--shadow-inner);
     transition:
         color var(--transition-fast),
         background-color var(--transition-fast),
-        border-color var(--transition-fast),
-        box-shadow var(--transition-fast),
-        transform var(--transition-fast);
+        border-color var(--transition-fast);
     white-space: nowrap;
     text-decoration: none;
     user-select: none;
@@ -34,16 +31,15 @@
 .btn:hover {
     background-color: var(--color-glass-hover);
     border-color: var(--color-border-hover);
-    box-shadow: var(--shadow-sm), var(--shadow-inner);
 }
 
 .btn:active {
-    transform: translateY(1px) scale(0.99);
+    background-color: var(--color-glass-active);
 }
 
 .btn:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px var(--color-accent-muted);
+    box-shadow: 0 0 0 2px var(--color-text-tertiary);
 }
 
 .btn:disabled {
@@ -83,13 +79,14 @@
 
 /* ========== Primary Button ========== */
 .btn-primary {
-    color: white;
-    background-color: var(--color-accent-active);
+    color: var(--color-bg-primary);
+    background-color: var(--color-accent);
     border-color: var(--color-accent);
 }
 
 .btn-primary:hover {
-    background-color: var(--color-accent);
+    color: var(--color-bg-primary);
+    background-color: var(--color-accent-hover);
     border-color: var(--color-accent-hover);
 }
 
@@ -99,7 +96,7 @@
 }
 
 .btn-primary:focus-visible {
-    box-shadow: 0 0 0 3px var(--color-accent-muted);
+    box-shadow: 0 0 0 2px var(--color-text-tertiary);
 }
 
 /* ========== Secondary Button ========== */
@@ -135,8 +132,8 @@
 }
 
 .btn-outline:hover {
-    color: white;
-    background-color: var(--color-accent-active);
+    color: var(--color-bg-primary);
+    background-color: var(--color-accent);
     border-color: var(--color-accent);
 }
 
@@ -291,26 +288,22 @@
     padding: 0 var(--spacing-8);
     font-size: var(--font-size-base);
     font-weight: var(--font-weight-semibold);
-    color: white;
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.18), transparent 48%),
-        linear-gradient(135deg, var(--color-accent-active), var(--color-accent));
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-accent), var(--shadow-inner);
+    color: var(--color-bg-primary);
+    background: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    border-radius: var(--radius-md);
     transition:
-        background var(--transition-base),
-        box-shadow var(--transition-base),
-        transform var(--transition-base);
+        background-color var(--transition-base),
+        border-color var(--transition-base);
 }
 
 .btn-generate:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 18px 38px -25px rgba(91, 141, 239, 0.86), var(--shadow-inner);
+    background: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
 }
 
 .btn-generate:active {
-    transform: translateY(1px) scale(0.995);
+    background: var(--color-accent-active);
 }
 
 .btn-generate:disabled {
@@ -330,17 +323,14 @@
     font-size: var(--font-size-base);
     font-weight: var(--font-weight-semibold);
     color: white;
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.14), transparent 50%),
-        linear-gradient(135deg, #bb4d4d, var(--color-error));
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-md);
+    background: var(--color-error);
+    border: 1px solid var(--color-error);
+    border-radius: var(--radius-md);
 }
 
 .btn-stop:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 18px 38px -25px rgba(225, 99, 99, 0.76), var(--shadow-inner);
+    background: #ff6b63;
+    border-color: #ff6b63;
 }
 
 /* ========== Theme Toggle Buttons ========== */
@@ -348,10 +338,9 @@
     display: flex;
     gap: var(--spacing-1);
     padding: var(--spacing-1);
-    background-color: rgba(255, 255, 255, 0.035);
+    background-color: var(--color-bg-tertiary);
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
-    box-shadow: var(--shadow-inner);
 }
 
 .theme-toggle-btn {
@@ -367,8 +356,7 @@
     cursor: pointer;
     transition:
         color var(--transition-fast),
-        background-color var(--transition-fast),
-        transform var(--transition-fast);
+        background-color var(--transition-fast);
 }
 
 .theme-toggle-btn:hover {
@@ -377,9 +365,8 @@
 }
 
 .theme-toggle-btn.is-active {
-    color: var(--color-accent);
+    color: var(--color-text-primary);
     background-color: var(--color-accent-muted);
-    box-shadow: var(--shadow-inner);
 }
 
 .theme-toggle-btn svg {
@@ -484,7 +471,7 @@
 }
 
 .btn-fab:hover {
-    transform: scale(1.05);
+    background-color: var(--color-glass-hover);
 }
 
 /* ========== Responsive ========== */
@@ -492,13 +479,13 @@
     .btn {
         padding: 0 var(--spacing-3);
     }
-    
+
     .btn-lg {
         height: var(--input-height);
         padding: 0 var(--spacing-4);
         font-size: var(--font-size-sm);
     }
-    
+
     .btn-generate {
         height: 44px;
         padding: 0 var(--spacing-6);

--- a/css/components.css
+++ b/css/components.css
@@ -5,17 +5,13 @@
 
 /* ========== Card ========== */
 .card {
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 44%),
-        var(--color-bg-secondary);
+    background: var(--color-bg-secondary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     padding: var(--spacing-4);
-    box-shadow: var(--shadow-inner);
     transition:
         border-color var(--transition-fast),
-        box-shadow var(--transition-fast),
-        transform var(--transition-fast);
+        box-shadow var(--transition-fast);
 }
 
 .card:hover {
@@ -28,14 +24,11 @@
 
 .card-interactive:hover {
     box-shadow: var(--shadow-md);
-    transform: translateY(-1px);
 }
 
 .card-glass {
-    background-color: var(--color-glass);
-    backdrop-filter: blur(var(--blur-md));
-    -webkit-backdrop-filter: blur(var(--blur-md));
-    border: 1px solid var(--color-glass-border);
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
 }
 
 /* ========== Badge ========== */
@@ -47,7 +40,7 @@
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-medium);
     border-radius: var(--radius-sm);
-    background-color: rgba(255, 255, 255, 0.04);
+    background-color: var(--color-bg-tertiary);
     color: var(--color-text-secondary);
 }
 
@@ -145,12 +138,10 @@
     left: 0;
     min-width: 180px;
     padding: var(--spacing-2);
-    background-color: rgba(25, 30, 41, 0.96);
+    background-color: var(--color-bg-elevated);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-xl);
-    backdrop-filter: blur(var(--blur-md));
-    -webkit-backdrop-filter: blur(var(--blur-md));
     z-index: var(--z-dropdown);
     opacity: 0;
     visibility: hidden;
@@ -201,9 +192,7 @@
 .modal-backdrop {
     position: fixed;
     inset: 0;
-    background-color: rgba(9, 11, 16, 0.7);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
+    background-color: rgba(0, 0, 0, 0.55);
     z-index: var(--z-modal-backdrop);
     opacity: 0;
     visibility: hidden;
@@ -303,12 +292,10 @@
     align-items: flex-start;
     gap: var(--spacing-3);
     padding: var(--spacing-4);
-    background-color: rgba(25, 30, 41, 0.96);
+    background-color: var(--color-bg-elevated);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-xl);
-    backdrop-filter: blur(var(--blur-md));
-    -webkit-backdrop-filter: blur(var(--blur-md));
     min-width: 300px;
     max-width: 400px;
     pointer-events: auto;
@@ -429,9 +416,7 @@
 .loading-overlay {
     position: fixed;
     inset: 0;
-    background-color: rgba(9, 11, 16, 0.72);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
+    background-color: rgba(0, 0, 0, 0.55);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -476,18 +461,8 @@
 }
 
 .progress-bar-animated {
-    background-image: linear-gradient(
-        45deg,
-        rgba(255, 255, 255, 0.15) 25%,
-        transparent 25%,
-        transparent 50%,
-        rgba(255, 255, 255, 0.15) 50%,
-        rgba(255, 255, 255, 0.15) 75%,
-        transparent 75%,
-        transparent
-    );
-    background-size: 1rem 1rem;
-    animation: progress-stripes 1s linear infinite;
+    background-image: none;
+    animation: none;
 }
 
 @keyframes progress-stripes {
@@ -501,14 +476,8 @@
 
 /* ========== Skeleton Loader ========== */
 .skeleton {
-    background: linear-gradient(
-        90deg,
-        var(--color-glass) 25%,
-        var(--color-glass-hover) 50%,
-        var(--color-glass) 75%
-    );
-    background-size: 200% 100%;
-    animation: skeleton-loading 1.5s ease-in-out infinite;
+    background: var(--color-bg-tertiary);
+    animation: pulse 1.5s ease-in-out infinite;
     border-radius: var(--radius-md);
 }
 
@@ -546,8 +515,7 @@
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     overflow: hidden;
-    background-color: rgba(255, 255, 255, 0.02);
-    box-shadow: var(--shadow-inner);
+    background-color: var(--color-bg-secondary);
 }
 
 .collapsible + .collapsible {
@@ -560,7 +528,7 @@
     align-items: center;
     justify-content: space-between;
     padding: var(--spacing-4);
-    background-color: rgba(255, 255, 255, 0.025);
+    background-color: var(--color-bg-tertiary);
     border: none;
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-medium);
@@ -599,7 +567,7 @@
 .collapsible-body {
     padding: var(--spacing-4);
     border-top: 1px solid var(--color-border);
-    background-color: rgba(255, 255, 255, 0.015);
+    background-color: var(--color-bg-secondary);
 }
 
 /* ========== Separator ========== */

--- a/css/forms.css
+++ b/css/forms.css
@@ -45,26 +45,24 @@
     padding: 0 var(--spacing-3);
     font-size: var(--font-size-sm);
     color: var(--color-text-primary);
-    background-color: rgba(255, 255, 255, 0.035);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    box-shadow: var(--shadow-inner);
     transition:
         background-color var(--transition-fast),
-        border-color var(--transition-fast),
-        box-shadow var(--transition-fast);
+        border-color var(--transition-fast);
 }
 
 .form-input:hover {
     border-color: var(--color-border-hover);
-    background-color: rgba(255, 255, 255, 0.052);
+    background-color: var(--color-bg-tertiary);
 }
 
 .form-input:focus {
     outline: none;
     border-color: var(--color-accent);
-    background-color: rgba(255, 255, 255, 0.06);
-    box-shadow: 0 0 0 3px var(--color-accent-muted), var(--shadow-inner);
+    background-color: var(--color-bg-tertiary);
+    box-shadow: 0 0 0 2px var(--color-accent-muted);
 }
 
 .form-input::placeholder {
@@ -174,15 +172,13 @@
     padding: 0 var(--spacing-10) 0 var(--spacing-3);
     font-size: var(--font-size-sm);
     color: var(--color-text-primary);
-    background-color: rgba(255, 255, 255, 0.035);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     cursor: pointer;
-    box-shadow: var(--shadow-inner);
     transition:
         background-color var(--transition-fast),
-        border-color var(--transition-fast),
-        box-shadow var(--transition-fast);
+        border-color var(--transition-fast);
     appearance: none;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23a0a0b0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
     background-repeat: no-repeat;
@@ -192,14 +188,14 @@
 
 .form-select:hover {
     border-color: var(--color-border-hover);
-    background-color: rgba(255, 255, 255, 0.052);
+    background-color: var(--color-bg-tertiary);
 }
 
 .form-select:focus {
     outline: none;
     border-color: var(--color-accent);
-    background-color: rgba(255, 255, 255, 0.06);
-    box-shadow: 0 0 0 3px var(--color-accent-muted), var(--shadow-inner);
+    background-color: var(--color-bg-tertiary);
+    box-shadow: 0 0 0 2px var(--color-accent-muted);
 }
 
 .form-select:disabled {
@@ -220,28 +216,26 @@
     font-size: var(--font-size-sm);
     font-family: inherit;
     color: var(--color-text-primary);
-    background-color: rgba(255, 255, 255, 0.035);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     resize: vertical;
-    box-shadow: var(--shadow-inner);
     transition:
         background-color var(--transition-fast),
-        border-color var(--transition-fast),
-        box-shadow var(--transition-fast);
+        border-color var(--transition-fast);
     line-height: var(--line-height-normal);
 }
 
 .form-textarea:hover {
     border-color: var(--color-border-hover);
-    background-color: rgba(255, 255, 255, 0.052);
+    background-color: var(--color-bg-tertiary);
 }
 
 .form-textarea:focus {
     outline: none;
     border-color: var(--color-accent);
-    background-color: rgba(255, 255, 255, 0.06);
-    box-shadow: 0 0 0 3px var(--color-accent-muted), var(--shadow-inner);
+    background-color: var(--color-bg-tertiary);
+    box-shadow: 0 0 0 2px var(--color-accent-muted);
 }
 
 .form-textarea::placeholder {
@@ -300,7 +294,7 @@
 
 .toggle-input:checked + .toggle-switch {
     background-color: var(--color-accent-active);
-    border-color: rgba(255, 255, 255, 0.16);
+    border-color: var(--color-accent-active);
 }
 
 .toggle-input:checked + .toggle-switch::after {
@@ -309,7 +303,7 @@
 }
 
 .toggle-input:focus-visible + .toggle-switch {
-    box-shadow: 0 0 0 3px var(--color-accent-muted);
+    box-shadow: 0 0 0 2px var(--color-accent-muted);
 }
 
 .toggle-input:disabled + .toggle-switch {
@@ -344,14 +338,12 @@
     align-items: center;
     justify-content: space-between;
     padding: var(--spacing-3) var(--spacing-4);
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    box-shadow: var(--shadow-inner);
     transition:
         background-color var(--transition-fast),
-        border-color var(--transition-fast),
-        transform var(--transition-fast);
+        border-color var(--transition-fast);
 }
 
 .toggle-option:hover {
@@ -399,12 +391,11 @@
     border-radius: var(--radius-full);
     cursor: pointer;
     transition: all var(--transition-fast);
-    box-shadow: var(--shadow-accent);
+    box-shadow: var(--shadow-sm);
 }
 
 .form-range::-webkit-slider-thumb:hover {
-    transform: scale(1.1);
-    box-shadow: 0 10px 24px -16px rgba(91, 141, 239, 0.88);
+    background-color: var(--color-accent-hover);
 }
 
 .form-range::-moz-range-thumb {
@@ -485,8 +476,7 @@
     height: 12px;
     color: white;
     opacity: 0;
-    transform: scale(0.5);
-    transition: all var(--transition-fast);
+    transition: opacity var(--transition-fast);
 }
 
 .checkbox-input:checked + .checkbox-box {
@@ -496,7 +486,6 @@
 
 .checkbox-input:checked + .checkbox-box svg {
     opacity: 1;
-    transform: scale(1);
 }
 
 .checkbox-input:focus-visible + .checkbox-box {
@@ -543,8 +532,7 @@
     background-color: white;
     border-radius: var(--radius-full);
     opacity: 0;
-    transform: scale(0);
-    transition: all var(--transition-fast);
+    transition: opacity var(--transition-fast);
 }
 
 .radio-input:checked + .radio-circle {
@@ -554,7 +542,6 @@
 
 .radio-input:checked + .radio-circle::after {
     opacity: 1;
-    transform: scale(1);
 }
 
 .radio-input:focus-visible + .radio-circle {

--- a/css/layout.css
+++ b/css/layout.css
@@ -21,15 +21,12 @@
     align-items: center;
     justify-content: space-between;
     padding: 0 var(--spacing-6);
-    background-color: rgba(16, 19, 26, 0.9);
+    background-color: var(--color-bg-secondary);
     border-bottom: 1px solid var(--color-border);
-    backdrop-filter: blur(var(--blur-md));
-    -webkit-backdrop-filter: blur(var(--blur-md));
-    box-shadow: var(--shadow-inner);
 }
 
 [data-theme="light"] .header {
-    background-color: rgba(255, 255, 255, 0.86);
+    background-color: var(--color-bg-secondary);
 }
 
 .header-left {
@@ -53,12 +50,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.16), transparent 46%),
-        linear-gradient(135deg, var(--color-accent-active), var(--color-accent));
+    background: var(--color-bg-tertiary);
     border-radius: var(--radius-md);
-    color: white;
-    box-shadow: var(--shadow-accent), var(--shadow-inner);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border);
 }
 
 .header-logo-icon svg {
@@ -98,15 +93,12 @@
     left: 0;
     display: flex;
     flex-direction: column;
-    background-color: rgba(16, 19, 26, 0.92);
+    background-color: var(--color-bg-secondary);
     border-right: 1px solid var(--color-border);
     overflow: hidden;
     flex-shrink: 0;
     z-index: var(--z-fixed);
     transition: width var(--transition-slow), transform var(--transition-slow);
-    box-shadow: var(--shadow-inner);
-    backdrop-filter: blur(var(--blur-md));
-    -webkit-backdrop-filter: blur(var(--blur-md));
 }
 
 [data-theme="light"] .sidebar {
@@ -134,8 +126,8 @@
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-semibold);
     color: var(--color-text-tertiary);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    text-transform: none;
+    letter-spacing: 0;
     margin-bottom: var(--spacing-3);
     padding: 0 var(--spacing-2);
 }
@@ -173,28 +165,24 @@
     width: 100%;
     max-width: var(--content-max-width);
     margin: 0 auto;
-    padding: var(--spacing-6);
+    padding: var(--spacing-5);
     overflow-y: auto;
     gap: var(--spacing-6);
 }
 
 /* ========== Panels ========== */
 .panel {
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 42%),
-        var(--color-bg-secondary);
+    background: var(--color-bg-secondary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-xl);
     overflow: hidden;
-    box-shadow: var(--shadow-lg);
+    box-shadow: none;
 }
 
 .panel-glass {
-    background-color: var(--color-glass);
-    backdrop-filter: blur(var(--blur-md));
-    -webkit-backdrop-filter: blur(var(--blur-md));
-    border: 1px solid var(--color-glass-border);
-    box-shadow: var(--shadow-lg);
+    background-color: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    box-shadow: none;
 }
 
 .panel-header {
@@ -203,8 +191,7 @@
     justify-content: space-between;
     padding: var(--spacing-4) var(--spacing-5);
     border-bottom: 1px solid var(--color-border);
-    background-color: rgba(255, 255, 255, 0.025);
-    box-shadow: var(--shadow-inner);
+    background-color: var(--color-bg-tertiary);
 }
 
 .panel-title {
@@ -239,7 +226,7 @@
 .panel-footer {
     padding: var(--spacing-4) var(--spacing-5);
     border-top: 1px solid var(--color-border);
-    background-color: rgba(255, 255, 255, 0.025);
+    background-color: var(--color-bg-tertiary);
 }
 
 /* ========== Request Panel ========== */
@@ -334,32 +321,30 @@
 @media (max-width: 1024px) {
     .sidebar {
         transform: translateX(-100%);
-        box-shadow: var(--shadow-xl);
+        box-shadow: var(--shadow-md);
     }
-    
+
     .sidebar.is-open {
         transform: translateX(0);
     }
-    
+
     .main-content {
         margin-left: 0;
     }
-    
-    .sidebar-overlay {
+
+.sidebar-overlay {
         display: none;
         position: fixed;
         inset: 0;
         top: var(--header-height);
-        background-color: rgba(9, 11, 16, 0.72);
-        backdrop-filter: blur(var(--blur-sm));
-        -webkit-backdrop-filter: blur(var(--blur-sm));
+        background-color: rgba(0, 0, 0, 0.5);
         z-index: calc(var(--z-fixed) - 1);
     }
-    
+
     .sidebar-overlay.is-visible {
         display: block;
     }
-    
+
     .content-area {
         padding: var(--spacing-4);
         max-width: none;
@@ -370,26 +355,26 @@
     .header {
         padding: 0 var(--spacing-4);
     }
-    
+
     .header-logo span {
         display: none;
     }
-    
+
     .split-layout {
         flex-direction: column;
     }
-    
+
     .content-area {
         padding: var(--spacing-3);
         gap: var(--spacing-4);
     }
-    
+
     .panel-body {
         padding: var(--spacing-4);
     }
 
     .panel {
-        border-radius: var(--radius-lg);
+        border-radius: var(--radius-md);
     }
 }
 
@@ -397,20 +382,20 @@
     :root {
         --header-height: 56px;
     }
-    
+
     .header {
         padding: 0 var(--spacing-3);
     }
-    
+
     .content-area {
         padding: var(--spacing-3);
         gap: var(--spacing-3);
     }
-    
+
     .panel-header {
         padding: var(--spacing-3) var(--spacing-4);
     }
-    
+
     .panel-body {
         padding: var(--spacing-3);
     }

--- a/css/output.css
+++ b/css/output.css
@@ -12,11 +12,10 @@
 
 /* ========== Output Area ========== */
 .output-area {
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     overflow: hidden;
-    box-shadow: var(--shadow-inner);
 }
 
 .output-area-empty {
@@ -78,7 +77,7 @@
     align-items: center;
     gap: var(--spacing-2);
     padding: var(--spacing-3) var(--spacing-4);
-    background-color: rgba(255, 255, 255, 0.025);
+    background-color: var(--color-bg-tertiary);
     border-bottom: 1px solid var(--color-border);
 }
 
@@ -111,7 +110,7 @@
     max-width: 100%;
     max-height: 500px;
     border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-xl);
+    box-shadow: var(--shadow-md);
     object-fit: contain;
 }
 
@@ -121,7 +120,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border-radius: var(--radius-lg);
 }
 
@@ -142,10 +141,9 @@
     align-items: center;
     gap: var(--spacing-3);
     padding: var(--spacing-4);
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border-radius: var(--radius-lg);
     border: 1px solid var(--color-border);
-    box-shadow: var(--shadow-inner);
 }
 
 .audio-player-btn {
@@ -165,7 +163,6 @@
 
 .audio-player-btn:hover {
     background-color: var(--color-accent);
-    transform: scale(1.05);
 }
 
 .audio-player-btn svg {
@@ -224,7 +221,7 @@
     align-items: center;
     justify-content: center;
     gap: var(--spacing-3);
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border-radius: var(--radius-lg);
 }
 
@@ -244,7 +241,7 @@
     gap: var(--spacing-3);
     padding: var(--spacing-4);
     border-top: 1px solid var(--color-border);
-    background-color: rgba(255, 255, 255, 0.025);
+    background-color: var(--color-bg-tertiary);
 }
 
 .download-btn {
@@ -278,10 +275,9 @@
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: var(--spacing-3);
     padding: var(--spacing-4);
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-inner);
 }
 
 .stat-item {
@@ -341,15 +337,14 @@
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-medium);
     color: var(--color-text-secondary);
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     cursor: pointer;
     transition:
         background-color var(--transition-fast),
         border-color var(--transition-fast),
-        color var(--transition-fast),
-        transform var(--transition-fast);
+        color var(--transition-fast);
 }
 
 .payload-tab-btn:hover {
@@ -363,13 +358,9 @@
     border-color: var(--color-accent);
 }
 
-.payload-tab-btn:active {
-    transform: translateY(1px);
-}
-
 .payload-content {
     position: relative;
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     overflow: hidden;
@@ -380,7 +371,7 @@
     align-items: center;
     justify-content: space-between;
     padding: var(--spacing-2) var(--spacing-3);
-    background-color: rgba(255, 255, 255, 0.025);
+    background-color: var(--color-bg-secondary);
     border-bottom: 1px solid var(--color-border);
 }
 
@@ -388,8 +379,8 @@
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-medium);
     color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    text-transform: none;
+    letter-spacing: 0;
 }
 
 .payload-code {
@@ -508,12 +499,12 @@
     .stats-area {
         grid-template-columns: repeat(2, 1fr);
     }
-    
+
     .output-text {
         padding: var(--spacing-4);
         max-height: 400px;
     }
-    
+
     .output-image {
         max-height: 400px;
     }
@@ -523,20 +514,20 @@
     .stats-area {
         grid-template-columns: 1fr;
     }
-    
+
     .output-actions {
         flex-direction: column;
     }
-    
+
     .download-btn {
         width: 100%;
         justify-content: center;
     }
-    
+
     .payload-tabs {
         flex-direction: column;
     }
-    
+
     .payload-tab-btn {
         width: 100%;
         text-align: center;

--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -9,14 +9,11 @@
     height: calc(100vh - var(--header-height));
     display: flex;
     flex-direction: column;
-    background-color: rgba(16, 19, 26, 0.92);
+    background-color: var(--color-bg-secondary);
     border-right: 1px solid var(--color-border);
     overflow: hidden;
     flex-shrink: 0;
     transition: width var(--transition-slow), transform var(--transition-slow);
-    box-shadow: var(--shadow-inner);
-    backdrop-filter: blur(var(--blur-md));
-    -webkit-backdrop-filter: blur(var(--blur-md));
 }
 
 /* ========== Sidebar Content ========== */
@@ -50,8 +47,8 @@
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-semibold);
     color: var(--color-text-tertiary);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    text-transform: none;
+    letter-spacing: 0;
 }
 
 .sidebar-section-title svg {
@@ -159,17 +156,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: rgba(255, 255, 255, 0.035);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     color: var(--color-text-secondary);
     cursor: pointer;
-    box-shadow: var(--shadow-inner);
     transition:
         color var(--transition-fast),
         background-color var(--transition-fast),
         border-color var(--transition-fast),
-        transform var(--transition-fast);
     flex-shrink: 0;
 }
 
@@ -177,10 +172,6 @@
     background-color: var(--color-glass-hover);
     border-color: var(--color-border-hover);
     color: var(--color-text-primary);
-}
-
-.model-refresh-btn:active {
-    transform: translateY(1px);
 }
 
 .model-refresh-btn.is-loading svg {
@@ -204,7 +195,7 @@
     text-align: center;
     color: var(--color-text-tertiary);
     font-size: var(--font-size-sm);
-    background-color: rgba(255, 255, 255, 0.025);
+    background-color: var(--color-bg-tertiary);
     border-radius: var(--radius-md);
     border: 1px dashed var(--color-border);
 }
@@ -214,10 +205,9 @@
     align-items: center;
     gap: var(--spacing-2);
     padding: var(--spacing-3);
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    box-shadow: var(--shadow-inner);
     transition:
         background-color var(--transition-fast),
         border-color var(--transition-fast);
@@ -310,7 +300,7 @@
     flex-direction: column;
     gap: var(--spacing-2);
     padding: var(--spacing-3);
-    background-color: rgba(255, 255, 255, 0.025);
+    background-color: var(--color-bg-tertiary);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
 }
@@ -371,17 +361,11 @@
     border-radius: var(--radius-md);
     color: var(--color-text-primary);
     cursor: pointer;
-    transition:
-        background-color var(--transition-fast),
-        transform var(--transition-fast);
+    transition: background-color var(--transition-fast);
 }
 
 .sidebar-toggle:hover {
     background-color: var(--color-glass-hover);
-}
-
-.sidebar-toggle:active {
-    transform: translateY(1px);
 }
 
 .sidebar-toggle svg {
@@ -395,12 +379,10 @@
     position: fixed;
     inset: 0;
     top: var(--header-height);
-    background-color: rgba(9, 11, 16, 0.72);
+    background-color: rgba(0, 0, 0, 0.55);
     z-index: calc(var(--z-fixed) - 1);
     opacity: 0;
     visibility: hidden;
-    backdrop-filter: blur(var(--blur-sm));
-    -webkit-backdrop-filter: blur(var(--blur-sm));
     transition: opacity var(--transition-base), visibility var(--transition-base);
 }
 
@@ -414,7 +396,7 @@
     .sidebar-toggle {
         display: flex;
     }
-    
+
     .sidebar {
         position: fixed;
         left: 0;
@@ -423,11 +405,11 @@
         transform: translateX(-100%);
         box-shadow: var(--shadow-xl);
     }
-    
+
     .sidebar.is-open {
         transform: translateX(0);
     }
-    
+
     .sidebar-overlay {
         display: block;
     }
@@ -438,7 +420,7 @@
         width: 100%;
         max-width: 320px;
     }
-    
+
     .config-item-actions {
         opacity: 1;
     }

--- a/css/tabs.css
+++ b/css/tabs.css
@@ -12,12 +12,12 @@
 /* ========== Tab List ========== */
 .tab-list {
     display: flex;
-    gap: var(--spacing-1);
-    padding: var(--spacing-2);
-    background-color: rgba(255, 255, 255, 0.032);
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--color-border);
-    box-shadow: var(--shadow-inner);
+    gap: var(--spacing-4);
+    padding: 0;
+    background-color: transparent;
+    border-radius: 0;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
 }
 
 .tab-list-pills {
@@ -48,33 +48,28 @@
     color: var(--color-text-secondary);
     background: transparent;
     border: none;
-    border-radius: var(--radius-md);
+    border-radius: 0;
     cursor: pointer;
     border: 1px solid transparent;
     transition:
         color var(--transition-fast),
         background-color var(--transition-fast),
-        border-color var(--transition-fast),
-        box-shadow var(--transition-fast),
-        transform var(--transition-fast);
+        border-color var(--transition-fast);
     white-space: nowrap;
     position: relative;
 }
 
 .tab-btn:hover {
     color: var(--color-text-primary);
-    background-color: var(--color-glass-hover);
+    background-color: transparent;
 }
 
 .tab-btn.is-active {
     color: var(--color-text-primary);
-    background-color: var(--color-bg-tertiary);
-    border-color: var(--color-border-hover);
-    box-shadow: var(--shadow-sm), var(--shadow-inner);
-}
-
-.tab-btn:active {
-    transform: translateY(1px);
+    background-color: transparent;
+    border-color: transparent;
+    border-bottom-color: var(--color-text-primary);
+    box-shadow: none;
 }
 
 .tab-btn svg {
@@ -104,8 +99,8 @@
 .tab-list-pills .tab-btn.is-active {
     background-color: var(--color-accent-active);
     border-color: var(--color-accent);
-    color: white;
-    box-shadow: var(--shadow-accent), var(--shadow-inner);
+    color: var(--color-bg-primary);
+    box-shadow: none;
 }
 
 /* ========== Tab Underline Variant ========== */
@@ -200,16 +195,15 @@
 }
 
 .generation-tabs .tab-list {
-    background-color: rgba(16, 19, 26, 0.78);
-    padding: var(--spacing-1);
+    background-color: transparent;
+    padding: 0;
     border-color: var(--color-border);
-    backdrop-filter: blur(var(--blur-sm));
-    -webkit-backdrop-filter: blur(var(--blur-sm));
 }
 
 .generation-tabs .tab-btn {
     flex: 1;
     justify-content: center;
+    border-bottom-width: 2px;
 }
 
 .generation-tabs .tab-btn svg {
@@ -219,10 +213,9 @@
 
 /* Tab icons with specific colors when active */
 .generation-tabs .tab-btn[data-tab="text"].is-active {
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent),
-        var(--color-accent-soft);
-    border-color: rgba(91, 141, 239, 0.32);
+    background: transparent;
+    border-color: transparent;
+    border-bottom-color: var(--color-text-primary);
 }
 
 .generation-tabs .tab-btn[data-tab="text"].is-active svg,
@@ -233,24 +226,21 @@
 }
 
 .generation-tabs .tab-btn[data-tab="image"].is-active {
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent),
-        var(--color-accent-soft);
-    border-color: rgba(91, 141, 239, 0.32);
+    background: transparent;
+    border-color: transparent;
+    border-bottom-color: var(--color-text-primary);
 }
 
 .generation-tabs .tab-btn[data-tab="audio"].is-active {
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent),
-        var(--color-accent-soft);
-    border-color: rgba(91, 141, 239, 0.32);
+    background: transparent;
+    border-color: transparent;
+    border-bottom-color: var(--color-text-primary);
 }
 
 .generation-tabs .tab-btn[data-tab="video"].is-active {
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent),
-        var(--color-accent-soft);
-    border-color: rgba(91, 141, 239, 0.32);
+    background: transparent;
+    border-color: transparent;
+    border-bottom-color: var(--color-text-primary);
 }
 
 /* ========== Disabled Tabs ========== */
@@ -303,34 +293,34 @@
         scrollbar-width: none;
         -ms-overflow-style: none;
     }
-    
+
     .tab-list::-webkit-scrollbar {
         display: none;
     }
-    
+
     .tab-btn {
         padding: var(--spacing-2) var(--spacing-3);
         font-size: var(--font-size-xs);
     }
-    
+
     .tab-btn span:not(.tab-badge) {
         display: none;
     }
-    
+
     .tab-btn svg {
         width: 20px;
         height: 20px;
     }
-    
+
     .generation-tabs .tab-btn {
         padding: var(--spacing-3);
         min-width: 74px;
     }
-    
+
     .tabs-vertical {
         flex-direction: column;
     }
-    
+
     .tabs-vertical .tab-list {
         width: 100%;
         flex-direction: row;
@@ -339,10 +329,9 @@
 
 @media (max-width: 480px) {
     .generation-tabs .tab-list {
-        gap: var(--spacing-1);
-        padding: 5px;
+        gap: var(--spacing-2);
     }
-    
+
     .generation-tabs .tab-btn {
         padding: var(--spacing-2);
         min-width: 64px;

--- a/css/variables.css
+++ b/css/variables.css
@@ -1,58 +1,58 @@
 /* ============================================
    API Tester v2 - CSS Variables
-   Calm Pro Design System
+   Normal App Design System
    ============================================ */
 
 :root {
     /* ========== Color Palette - Dark Theme (Default) ========== */
-    --color-bg-primary: #090b10;
-    --color-bg-secondary: #10131a;
-    --color-bg-tertiary: #151922;
-    --color-bg-elevated: #191e29;
-    
-    /* Glass Effect Colors */
-    --color-glass: rgba(255, 255, 255, 0.035);
-    --color-glass-hover: rgba(255, 255, 255, 0.07);
-    --color-glass-active: rgba(255, 255, 255, 0.1);
-    --color-glass-border: rgba(255, 255, 255, 0.08);
-    --color-glass-border-hover: rgba(255, 255, 255, 0.14);
-    
+    --color-bg-primary: #0f0f0f;
+    --color-bg-secondary: #171717;
+    --color-bg-tertiary: #202020;
+    --color-bg-elevated: #242424;
+
+    /* Surface State Colors */
+    --color-glass: #1b1b1b;
+    --color-glass-hover: #232323;
+    --color-glass-active: #2b2b2b;
+    --color-glass-border: #303030;
+    --color-glass-border-hover: #3a3a3a;
+
     /* Text Colors */
-    --color-text-primary: #f8fafc;
-    --color-text-secondary: #aab4c3;
-    --color-text-tertiary: #6f7b8d;
-    --color-text-muted: #465061;
-    
+    --color-text-primary: #f5f5f5;
+    --color-text-secondary: #b3b3b3;
+    --color-text-tertiary: #858585;
+    --color-text-muted: #5f5f5f;
+
     /* Accent Colors */
-    --color-accent: #5b8def;
-    --color-accent-hover: #7aa4f4;
-    --color-accent-active: #4677d2;
-    --color-accent-muted: rgba(91, 141, 239, 0.14);
-    --color-accent-soft: rgba(91, 141, 239, 0.08);
-    
+    --color-accent: #e5e5e5;
+    --color-accent-hover: #ffffff;
+    --color-accent-active: #d4d4d4;
+    --color-accent-muted: #2a2a2a;
+    --color-accent-soft: #1e1e1e;
+
     /* Semantic Colors */
-    --color-success: #48b981;
-    --color-success-muted: rgba(72, 185, 129, 0.14);
-    --color-error: #e16363;
-    --color-error-muted: rgba(225, 99, 99, 0.14);
-    --color-warning: #d6a24d;
-    --color-warning-muted: rgba(214, 162, 77, 0.14);
-    --color-info: #5b8def;
-    --color-info-muted: rgba(91, 141, 239, 0.14);
-    
+    --color-success: #3fb950;
+    --color-success-muted: rgba(63, 185, 80, 0.12);
+    --color-error: #f85149;
+    --color-error-muted: rgba(248, 81, 73, 0.12);
+    --color-warning: #d29922;
+    --color-warning-muted: rgba(210, 153, 34, 0.12);
+    --color-info: #8b949e;
+    --color-info-muted: rgba(139, 148, 158, 0.14);
+
     /* Border Colors */
-    --color-border: rgba(255, 255, 255, 0.075);
-    --color-border-hover: rgba(255, 255, 255, 0.16);
+    --color-border: #303030;
+    --color-border-hover: #444444;
     --color-border-focus: var(--color-accent);
-    
+
     /* Shadow Colors */
-    --shadow-color: rgba(3, 7, 18, 0.36);
-    --shadow-color-strong: rgba(3, 7, 18, 0.58);
-    
+    --shadow-color: rgba(0, 0, 0, 0.22);
+    --shadow-color-strong: rgba(0, 0, 0, 0.32);
+
     /* ========== Typography ========== */
-    --font-family-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    --font-family-sans: 'Geist', ui-sans-serif, sans-serif;
     --font-family-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', Monaco, 'Cascadia Code', monospace;
-    
+
     /* Font Sizes */
     --font-size-xs: 0.75rem;     /* 12px */
     --font-size-sm: 0.8125rem;   /* 13px */
@@ -62,18 +62,18 @@
     --font-size-xl: 1.25rem;     /* 20px */
     --font-size-2xl: 1.5rem;     /* 24px */
     --font-size-3xl: 1.875rem;   /* 30px */
-    
+
     /* Font Weights */
     --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
-    
+
     /* Line Heights */
     --line-height-tight: 1.25;
     --line-height-normal: 1.5;
     --line-height-relaxed: 1.75;
-    
+
     /* ========== Spacing ========== */
     --spacing-0: 0;
     --spacing-1: 0.25rem;   /* 4px */
@@ -86,21 +86,21 @@
     --spacing-10: 2.5rem;   /* 40px */
     --spacing-12: 3rem;     /* 48px */
     --spacing-16: 4rem;     /* 64px */
-    
+
     /* ========== Border Radius ========== */
     --radius-sm: 0.375rem;  /* 6px */
     --radius-md: 0.5rem;    /* 8px */
-    --radius-lg: 0.75rem;   /* 12px */
-    --radius-xl: 1rem;      /* 16px */
-    --radius-2xl: 1.5rem;   /* 24px */
+    --radius-lg: 0.625rem;  /* 10px */
+    --radius-xl: 0.75rem;   /* 12px */
+    --radius-2xl: 0.75rem;  /* 12px */
     --radius-full: 9999px;
-    
+
     /* ========== Layout ========== */
-    --sidebar-width: 280px;
+    --sidebar-width: 260px;
     --sidebar-width-collapsed: 60px;
     --header-height: 60px;
     --content-max-width: 1400px;
-    
+
     /* ========== Z-Index Scale ========== */
     --z-dropdown: 100;
     --z-sticky: 200;
@@ -110,27 +110,27 @@
     --z-popover: 600;
     --z-tooltip: 700;
     --z-toast: 800;
-    
+
     /* ========== Transitions ========== */
-    --transition-fast: 160ms cubic-bezier(0.16, 1, 0.3, 1);
-    --transition-base: 220ms cubic-bezier(0.16, 1, 0.3, 1);
-    --transition-slow: 320ms cubic-bezier(0.16, 1, 0.3, 1);
-    --transition-slower: 520ms cubic-bezier(0.16, 1, 0.3, 1);
-    
-    /* ========== Glassmorphism Effects ========== */
+    --transition-fast: 140ms ease;
+    --transition-base: 180ms ease;
+    --transition-slow: 220ms ease;
+    --transition-slower: 300ms ease;
+
+    /* ========== Blur Scale ========== */
     --blur-sm: 8px;
     --blur-md: 12px;
     --blur-lg: 20px;
     --blur-xl: 40px;
-    
+
     /* ========== Shadows ========== */
-    --shadow-sm: 0 1px 2px rgba(3, 7, 18, 0.24);
-    --shadow-md: 0 12px 24px -18px var(--shadow-color), 0 1px 0 rgba(255, 255, 255, 0.04) inset;
-    --shadow-lg: 0 22px 48px -30px var(--shadow-color-strong), 0 1px 0 rgba(255, 255, 255, 0.05) inset;
-    --shadow-xl: 0 30px 70px -42px var(--shadow-color-strong), 0 1px 0 rgba(255, 255, 255, 0.05) inset;
-    --shadow-accent: 0 14px 34px -24px rgba(91, 141, 239, 0.72);
-    --shadow-inner: inset 0 1px 0 rgba(255, 255, 255, 0.055);
-    
+    --shadow-sm: 0 1px 2px var(--shadow-color);
+    --shadow-md: 0 2px 8px var(--shadow-color);
+    --shadow-lg: 0 2px 8px var(--shadow-color);
+    --shadow-xl: 0 2px 8px var(--shadow-color-strong);
+    --shadow-accent: 0 1px 2px var(--shadow-color);
+    --shadow-inner: none;
+
     /* ========== Input Specific ========== */
     --input-height: 40px;
     --input-height-sm: 32px;
@@ -139,39 +139,42 @@
 
 /* ========== Light Theme ========== */
 [data-theme="light"] {
-    --color-bg-primary: #f6f7f9;
+    --color-bg-primary: #f7f7f7;
     --color-bg-secondary: #ffffff;
-    --color-bg-tertiary: #eef2f6;
+    --color-bg-tertiary: #f2f2f2;
     --color-bg-elevated: #ffffff;
-    
-    /* Glass Effect Colors - Light */
-    --color-glass: rgba(255, 255, 255, 0.72);
-    --color-glass-hover: rgba(255, 255, 255, 0.9);
-    --color-glass-active: rgba(255, 255, 255, 0.98);
-    --color-glass-border: rgba(15, 23, 42, 0.08);
-    --color-glass-border-hover: rgba(15, 23, 42, 0.14);
-    
+
+    /* Surface State Colors - Light */
+    --color-glass: #f4f4f4;
+    --color-glass-hover: #eeeeee;
+    --color-glass-active: #e8e8e8;
+    --color-glass-border: #d8d8d8;
+    --color-glass-border-hover: #c9c9c9;
+
     /* Text Colors - Light */
-    --color-text-primary: #162033;
-    --color-text-secondary: #5b677a;
-    --color-text-tertiary: #8a96a8;
-    --color-text-muted: #b9c1ce;
-    
+    --color-text-primary: #1f1f1f;
+    --color-text-secondary: #555555;
+    --color-text-tertiary: #777777;
+    --color-text-muted: #a0a0a0;
+
     /* Border Colors - Light */
-    --color-border: rgba(15, 23, 42, 0.08);
-    --color-border-hover: rgba(15, 23, 42, 0.14);
-    
+    --color-border: #d8d8d8;
+    --color-border-hover: #bfbfbf;
+
     /* Shadow Colors - Light */
-    --shadow-color: rgba(15, 23, 42, 0.08);
-    --shadow-color-strong: rgba(15, 23, 42, 0.16);
-    
+    --shadow-color: rgba(0, 0, 0, 0.08);
+    --shadow-color-strong: rgba(0, 0, 0, 0.12);
+
     /* Accent adjustments for light theme */
-    --color-accent-muted: rgba(91, 141, 239, 0.11);
-    --color-accent-soft: rgba(91, 141, 239, 0.06);
+    --color-accent: #1f1f1f;
+    --color-accent-hover: #000000;
+    --color-accent-active: #333333;
+    --color-accent-muted: #e8e8e8;
+    --color-accent-soft: #f2f2f2;
     --color-success-muted: rgba(72, 185, 129, 0.1);
     --color-error-muted: rgba(225, 99, 99, 0.1);
     --color-warning-muted: rgba(214, 162, 77, 0.1);
-    --color-info-muted: rgba(91, 141, 239, 0.1);
+    --color-info-muted: rgba(139, 148, 158, 0.12);
 }
 
 /* ========== Scrollbar Styling ========== */
@@ -183,6 +186,6 @@
 }
 
 [data-theme="light"] {
-    --scrollbar-thumb: rgba(15, 23, 42, 0.15);
-    --scrollbar-thumb-hover: rgba(15, 23, 42, 0.25);
+    --scrollbar-thumb: rgba(0, 0, 0, 0.18);
+    --scrollbar-thumb-hover: rgba(0, 0, 0, 0.28);
 }


### PR DESCRIPTION
Reworks the API Tester UI using the attached Uncodixify direction: normal app chrome, solid surfaces, simple borders, smaller radii, no gradients, no blur/glass treatment, no glow-driven hierarchy, and no blue premium SaaS look.

Normalizes the sidebar, header, tabs, buttons, forms, panels, output states, and README copy while keeping JS contracts and API behavior unchanged.

Validation: git diff --check; static style scan for banned gradient/blur/glow/blue/font patterns; local Chrome checks at 1440x1000 and 390x844 confirmed no overflow, no console errors, and working theme/tabs/sidebar/advanced-options interactions.